### PR TITLE
Fix nextjs-blog-starter broken image links on GitHub Pages

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -30,6 +30,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Get github repository name
+        id: github-repository
+        run: echo "name=${GITHUB_REPOSITORY#${GITHUB_REPOSITORY_OWNER}/}" >> $GITHUB_OUTPUT
       - name: Detect package manager
         id: detect-package-manager
         run: |
@@ -74,6 +77,8 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
+        env:
+          URL_PREFIX: ${{ steps.github-repository.outputs.name }}
       - name: Static HTML export with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next export
       - name: Upload artifact

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const urlPrefix = process.env.URL_PREFIX ? `/${process.env.URL_PREFIX}` : ''
+
+module.exports = {
+  assetPrefix: urlPrefix,
+  basePath: urlPrefix,
+  trailingSlash: true,
+}


### PR DESCRIPTION
- bf55d82256b08e747a199cc73660774a1d590a3f Change the `assetPrefix` and `basePath` for GitHub Pages
- a64e9b50a2ce34b35094b03fcf01b1f29a4a1677 Assign the GitHub repository name to URL_PREFIX env
