### PR TITLE
Assign `NODE_ENV` env in GitHub Actions

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -74,8 +74,12 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
+        env:
+          NODE_ENV: production
       - name: Static HTML export with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next export
+        env:
+          NODE_ENV: production
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:


### PR DESCRIPTION
fix: https://github.com/codenote-net/nextjs-blog-starter-sandbox/pull/5

- [next\.config\.js Options: assetPrefix \| Next\.js](https://nextjs.org/docs/pages/api-reference/next-config-js/assetPrefix)
